### PR TITLE
Feature/14 메인페이지 검색바,태그

### DIFF
--- a/src/apis/maindata.api.ts
+++ b/src/apis/maindata.api.ts
@@ -1,0 +1,11 @@
+import httpClient from '@/apis/http.api';
+import { mainData } from '@/model/main.model';
+
+export const fetchMainData = async () => {
+  const response = await httpClient.get<mainData>('/api/main');
+  try {
+    return response.data;
+  } catch {
+    throw Error;
+  }
+}

--- a/src/components/main-page/MainTagList.tsx
+++ b/src/components/main-page/MainTagList.tsx
@@ -1,0 +1,58 @@
+import { useMainTags } from '@/hooks/useMainTags';
+import { useSearchParams } from 'react-router';
+import { useState } from 'react';
+import styled from 'styled-components';
+
+
+const MainTagList = () => {
+  const { maintags } = useMainTags();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const handleTags = (id:number | null) => {
+    const newSearchParams = new URLSearchParams(searchParams);
+    if(id === null) {
+      newSearchParams.delete('id',);
+    } else {
+      newSearchParams.set('id', id.toString());
+    }
+    setSearchParams(newSearchParams);
+  }
+
+  return (
+    <MainTagListContainer>
+      {
+        maintags.map((tag)=>(<TagButton className={tag.isActive? 'active' : ''} key={tag.id} onClick={()=>handleTags(tag.id)}>{tag.name}</TagButton>))
+      }
+    </MainTagListContainer>
+  );
+}
+
+const MainTagListContainer = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+
+`;
+
+const TagButton = styled.button`
+  border-radius: 30px;
+  font-size: 1.1rem;
+  background-color: transparent;
+  color: #32C040;
+  border: 1px solid #32C040;
+  padding: 8px 20px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 0.12s ease-in-out;
+
+  &:hover {
+    background-color: rgba(49, 191, 63, 0.23);
+  }
+
+  &.active {
+    background-color: rgba(49, 191, 63, 0.23);
+  }
+
+`;
+
+export default MainTagList;

--- a/src/components/main-page/SearchInput.tsx
+++ b/src/components/main-page/SearchInput.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { MagnifyingGlassIcon as SearchIcon} from '@heroicons/react/24/outline';
+const SearchInput = () => {
+  const [searchText, setSearchText] = useState('');
+  const handleSearchChange = (e:React.ChangeEvent<HTMLInputElement>) => {
+    const inputText = e.target.value;
+    setSearchText(inputText);
+  }
+  return (
+    <SearchInputStyle>
+      <input type='text' value={searchText} onChange={handleSearchChange} />
+      <button><SearchIcon color='#727272' /></button>
+    </SearchInputStyle>
+  );
+}
+
+const SearchInputStyle = styled.div`
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  padding: 8px 20px;
+  border: 1px solid #727272;
+  border-radius: 30px;
+  width: 70%;
+
+  input {
+    width: 95%;
+    font-size: 1.2rem;
+    font-weight: 500;
+    border: 0;
+    padding: 5px;
+  }
+
+  button {
+    background-color: transparent;
+    border: 0;
+    margin-left: 10px;
+    cursor: pointer;
+    svg {
+      width: 24px;
+      height: 24px;
+    }
+  }
+
+
+`;
+
+export default SearchInput;

--- a/src/hooks/useMainTags.ts
+++ b/src/hooks/useMainTags.ts
@@ -1,0 +1,48 @@
+import { fetchMainData } from '@/apis/maindata.api';
+import { mainTags } from '@/model/main.model';
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router';
+
+export const useMainTags = () => {
+  const location = useLocation();
+  const [maintags, setMaintags] = useState<mainTags[]>([]);
+  
+  const setActive = () => {
+    const params = new URLSearchParams(location.search);
+    if(params.get('id')) {
+      setMaintags((prev)=> {
+        return prev.map((item) => {
+          return {...item, isActive: item.id === Number(params.get('id'))}
+        })
+      })
+    } else {
+      setMaintags((prev) => {
+        return prev.map((item) => {
+          return {...item, isActive: false}
+        })
+      })
+    }
+  }
+
+  useEffect(()=>{
+    fetchMainData().then((data) => {
+      if(!data.tags) return;
+      const tagsAll = [
+        {
+          id: null,
+          name: '전체',
+        },
+        ...data.tags,
+      ]
+
+      setMaintags(tagsAll);
+      setActive();
+    })
+  }, []);
+
+  useEffect(()=>{
+    setActive();
+  }, [location.search]);
+
+  return { maintags };
+}

--- a/src/model/main.model.ts
+++ b/src/model/main.model.ts
@@ -13,6 +13,10 @@ export interface mainPosts {
   created_at: string;
   updated_at: string;
   solved: boolean;
+  nickname: string;
+  comment_count: number;
+  like_count: number;
+  tags: string;
 }
 export interface mainData {
   users: mainUsers;

--- a/src/model/main.model.ts
+++ b/src/model/main.model.ts
@@ -1,0 +1,21 @@
+export interface mainUsers {
+  users: string | null;
+}
+export interface mainTags {
+  id: number | null;
+  name: string;
+  isActive?: boolean;
+}
+export interface mainPosts {
+  id: number;
+  title: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+  solved: boolean;
+}
+export interface mainData {
+  users: mainUsers;
+  tags: mainTags[];
+  posts: mainPosts[];
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,9 @@
 import MainTagList from '@/components/main-page/MainTagList';
+import SearchInput from '@/components/main-page/SearchInput';
 
 const HomePage = () => {
   return <div>
+    <SearchInput />
     <MainTagList />
   </div>;
 };

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,9 @@
+import MainTagList from '@/components/main-page/MainTagList';
+
 const HomePage = () => {
-  return <div>HomePage</div>;
+  return <div>
+    <MainTagList />
+  </div>;
 };
 
 export default HomePage;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -39,9 +39,7 @@ function LoginPage() {
   };
 
   // 로그인 상태 확인 후 리다이렉트 처리
-  if (isLoggedIn) {
-    navigate('/');
-  }
+
   return (
     <Container>
       <InnerWrapper>


### PR DESCRIPTION
## #️⃣연관된 이슈
#14 

## 📝작업 내용

메인페이지 작업

1. 검색바 생성(UI만) 55febec
2. 메인페이지 전체 데이터 가져오기 API 84dadfd
3. 태그리스트 커스텀훅(태그리스트만 가져오도록 설정 및 쿼리스트링으로 받은 태그 클릭시 불리언타입 넣어주는 로직 추가) 463d147
4. 태그리스트 컴포넌트 생성  4efd016
### 스크린샷
![Screen Shot 2024-12-16 at 10 34 14 PM](https://github.com/user-attachments/assets/ffc028df-d8ed-4cef-b34f-ff3ff665b8f4)



## 💬리뷰 요구사항(선택)
찬님 메인컨텐츠데이터 가져오는 api를 이용해보려 했지만 머지가 되지 않은상태여서 제가 만들어서 사용했습니다~ 나중에 겹치는 부분은 수정해야할 것 같아요,,!
폴더 구조도 다를 것으로 예상되어서 확인 후에 merge 필요할 것 같습니다!
